### PR TITLE
Bump to upstream version v0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go-assert-boring.sh bin/*
 
 # Build node feature discovery
 ARG ARCH="amd64"
-ARG TAG="v0.15.4"
+ARG TAG=v0.16.0
 ARG PKG="github.com/kubernetes-sigs/node-feature-discovery"
 RUN git clone --depth=1 https://${PKG}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SRC ?= "github.com/kubernetes-sigs/node-feature-discovery"
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v0.15.4$(BUILD_META)
+TAG := v0.16.0$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest upstream version in Dockerfile</summary>
            <p>changed lines [19] of file &#34;/tmp/updatecli/github/rancher/image-build-node-feature-discovery/Dockerfile&#34;</p>
            <details>
                <summary>v0.16.0</summary>
                <pre>&#xA;Release published on the 2024-05-27 17:08:21 +0000 UTC at the url https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.16.0&#xA;&#xA;## Changelog&#xD;&#xA;&#xD;&#xA;### NodeFeatureGroup API&#xD;&#xA;&#xD;&#xA;The NodeFeatureGroup custom resource was added to the NFD API. The NodeFeatureGroup API enables the creation of node groups based on features discovered by NFD. The API is an alpha feature and is disabled by default and can be enabled with the NodeFeatureGroupAPI [feature gate](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/usage/custom-resources.html#nodefeaturegroup).&#xD;&#xA;&#xD;&#xA;See [documentation](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/usage/custom-resources.html#nodefeaturegroup) for more details.&#xD;&#xA;&#xD;&#xA;### Feature gates&#xD;&#xA;&#xD;&#xA;NFD adapted the concept of feature gates from Kubernetes to introduce and stabilize new features in a controlled way. See the [documentation](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/feature-gates.html) for more details. Two existing features ([NodeFeature API](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/feature-gates.html#nodefeatureapi) and [disabling label auto-prefixing](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/feature-gates.html#disableautoprefix)) were converted into feature gates.&#xD;&#xA;&#xD;&#xA;### Deprecations&#xD;&#xA;&#xD;&#xA;#### Upcoming changes&#xD;&#xA;&#xD;&#xA;Support for [hooks](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/usage/customization-guide.html#hooks) is deprecated since [v0.12.0](https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.12.0) and will be completely dropped in the NFD v0.17.&#xD;&#xA;&#xD;&#xA;#### RDT feature labels removed&#xD;&#xA;&#xD;&#xA;The `feature.node.kubernetes.io/cpu-rdt.*` feature labels that were deprecated in NFD [v0.13](https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.13.0) were removed. RDT features are still available for use in [NodeFeatureRules](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/usage/custom-resources.html#nodefeaturerule) for custom labels.&#xD;&#xA;&#xD;&#xA;#### Deprecated flags and options&#xD;&#xA;&#xD;&#xA;The [autoDefaultNs](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/master-configuration-reference.html#autodefaultns) config file option of nfd-master is deprecated and will be removed in NFD v0.17. Superseded by the [DisableAutoPrefix](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/feature-gates.html#disableautoprefix) feature gate (`featureGates.DisableAutoPrefix` Helm parameter).&#xD;&#xA;&#xD;&#xA;The `-enable-nodefeature-api` command line flag of nfd-master and nfd-worker and the corresponding `enableNodeFeatureApi` [Helm chart parameter](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/deployment/helm.html#general-parameters) have been deprecated and will be removed in NFD v0.17. Superseded by the [NodeFeature API](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/feature-gates.html#nodefeatureapi) feature gate (`featureGates.NodeFeatureAPI` Helm parameter).&#xD;&#xA;&#xD;&#xA;The `-crd-controller` command line flag of nfd-master is deprecated and will be removed with the gRPC API in a future release.&#xD;&#xA;&#xD;&#xA;### Miscellaneous&#xD;&#xA;&#xD;&#xA;#### Network devices&#xD;&#xA;&#xD;&#xA;Discover speed of virtual network interfaces.&#xD;&#xA;&#xD;&#xA;#### DMI&#xD;&#xA;&#xD;&#xA;Added support for detecting DMI attributes from `/sys/devices/virtual/dmi/id/`. In v0.16 only `sys_vendor` discovered, available as `system.dmiid.sys_vendor` feature for use in [NodeFeatureRules](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/usage/custom-resources.html#nodefeaturerule).&#xD;&#xA;&#xD;&#xA;#### Swap&#xD;&#xA;&#xD;&#xA;Discover the availability of swap on the node. Available as `memory.swap.enabled` feature for use in [NodeFeatureRules](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/usage/custom-resources.html#nodefeaturerule).&#xD;&#xA;&#xD;&#xA;#### Helm chart&#xD;&#xA;&#xD;&#xA;Now all nodes are cleaned up (feature labels, annotations, extended resources and taints are removed) after uninstalling NFD using a post-delete hook.&#xD;&#xA;&#xD;&#xA;The Helm chart now sets resource requests (cpu and memory) for NFD pods. Users may want to adjust these for their cluster. An option to set the pod priority class was added. See [Helm chart parameters](https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/deployment/helm.html#chart-parameters) in the documentation).&#xD;&#xA;&#xD;&#xA;#### Container health&#xD;&#xA;&#xD;&#xA;A gRPC health server was added to the nfd-master, nfd-worker and nfd-topology-updater daemons. Deployments (Helm and kustomize) configure container liveness and readiness probes to use that for health checking.&#xD;&#xA;&#xD;&#xA;## List of PRs&#xD;&#xA;&#xD;&#xA;- github: update tagging instructions in release checklists (#1527)&#xD;&#xA;- Update readme to v0.15.0 release (#1524)&#xD;&#xA;- makefile: fix build: target (#1528)&#xD;&#xA;- Makefile: add -timeout argument to e2e-tests (#1526)&#xD;&#xA;- helm: add post-delete hook that cleans up the node (#1532)&#xD;&#xA;- deployment/kustomize: drop the sample cert-manager overlay (#1534)&#xD;&#xA;- nfd-master: run a separate gRPC health server (#1535)&#xD;&#xA;- source/network: discover speed of virtual network interfaces (#1536)&#xD;&#xA;- go.mod: update dependencies (#1539)&#xD;&#xA;- chore: combine cpu count and thread_siblings functions into discover topology function (#1505)&#xD;&#xA;- source/cpu: drop deprecated cpu-rdt labels (#1530)&#xD;&#xA;- Update readme to v0.15.1 release (#1552)&#xD;&#xA;- hack/generate: patch auto-generated deepcopy functions (#1553)&#xD;&#xA;- apis/nfd: Trivial typo fix in tests (#1537)&#xD;&#xA;- docs: update docs build dependencies (#1543)&#xD;&#xA;- topology-updater: initialize properly with -no-publish (#1554)&#xD;&#xA;- topology-updater: document the -no-publish flag correctly (#1555)&#xD;&#xA;- Wrap nested errors (#1558)&#xD;&#xA;- Prevent `nfd-worker` erroring when reading attributes from paravirtual devices (#1557)&#xD;&#xA;- pkg/utils: move GetKubeconfig from pkg/apihelper here (#1562)&#xD;&#xA;- OWNERS: add AhmedGrati as a reviewer (#1564)&#xD;&#xA;- deployment/helm: don&#39;t deploy topology-updater conf unnecessarily (#1565)&#xD;&#xA;- topology-updater: get topology api client directly (#1566)&#xD;&#xA;- pkg/utils: move JsonPatch from pkg/apihelper (#1568)&#xD;&#xA;- nfd-master: ditch apihelper (#1570)&#xD;&#xA;- topology-updater: ditch apihelper (#1567)&#xD;&#xA;- Drop pkg/apihelper (#1561)&#xD;&#xA;- nfd-master: fix node status patching (#1571)&#xD;&#xA;- nfd-topology-updater add pods fingerprint by default (#1560)&#xD;&#xA;- docs: add KEP of Spiffe integration (#1444)&#xD;&#xA;- docs: document removal of hooks in v0.17 (#1573)&#xD;&#xA;- build(deps): bump github.com/opencontainers/runc from 1.1.10 to 1.1.12 (#1575)&#xD;&#xA;- build(deps-dev): bump nokogiri from 1.16.0 to 1.16.2 in /docs (#1576)&#xD;&#xA;- scripts/test-infra: bump golangci-lint to v1.56.1 (#1580)&#xD;&#xA;- scripts/test-infra: bump k8s logcheck to v0.8.1 (#1583)&#xD;&#xA;- Bump Go to v1.22 (#1579)&#xD;&#xA;- scripts/test-infra: bump helm to v3.14.0 (#1582)&#xD;&#xA;- source/kernel: add unit tests for kernel version parsing (#1588)&#xD;&#xA;- helm: add priorityClassName option (#1587)&#xD;&#xA;- source/pci: add unit test for the pci source (#1589)&#xD;&#xA;- nfd-master: log errors on node update retries (#1591)&#xD;&#xA;- source/system: Add reading vendor information (#1574)&#xD;&#xA;- source/cpu: fix build tags on rdt discovery (#1594)&#xD;&#xA;- helm: add ability to use a custom issuer (#1598)&#xD;&#xA;- fix hook issue (#1604)&#xD;&#xA;- generate: update autogenerate tools (#1606)&#xD;&#xA;- apis/nfd/validate: use testify/assert for checking test results (#1590)&#xD;&#xA;- Update readme to v0.15.2 release (#1611)&#xD;&#xA;- Update generate scripts to use latest code_gen functions (#1605)&#xD;&#xA;- nfd-master: mark the -crd-controller flag as deprecated (#1612)&#xD;&#xA;- build(deps): bump google.golang.org/protobuf from 1.32.0 to 1.33.0 (#1613)&#xD;&#xA;- Use close to signal stop channedl in worker and topology-updater (#1620)&#xD;&#xA;- nfd-master: fix memory leak in nfd api-controller (#1615)&#xD;&#xA;- Update readme to v0.15.3 release (#1628)&#xD;&#xA;- Add FeatureGate framework to handle new features (#1623)&#xD;&#xA;- replace AhmedGrati account with TessaIO as reviewer (#1630)&#xD;&#xA;- add swap support in nfd (#1585)&#xD;&#xA;- nfd-master: check if node exists before trying update (#1595)&#xD;&#xA;- Remove references to -enable-nodefeature-api flag (#1632)&#xD;&#xA;- Add owner reference to NRT object (#1602)&#xD;&#xA;- nfd-master: retry node updates indefinitely (#1596)&#xD;&#xA;- nfd-worker: Add liveness probe (#1609)&#xD;&#xA;- topology-updater: Set APIVersion, Kind in the OwnerReference explicitly (#1634)&#xD;&#xA;- helm: fix invalid name of host-swaps volume (#1635)&#xD;&#xA;- nfd-master: do nfd API scheme registration in an init function (#1641)&#xD;&#xA;- chore/deployment: add resources requests and limits for helm and Kustomize (#1631)&#xD;&#xA;- nfd-topology-updater: Add liveness probe (#1643)&#xD;&#xA;- nfd-master: get node object only once when updating node (#1652)&#xD;&#xA;- chore/deploy: make interval property in PodMonitor configurable (#1639)&#xD;&#xA;- nfd-master: protect node updater pool queueing with a lock (#1642)&#xD;&#xA;- nfd-master: prevent crash on empty config struct (#1657)&#xD;&#xA;- Update readme to v0.15.4 release (#1650)&#xD;&#xA;- Tidy up usage of channels for signaling (#1656)&#xD;&#xA;- nfd-master: implement opts for modifying NfdMaster instance (#1658)&#xD;&#xA;- nfd-master: parse kubeconfig even with NoPublish set (#1655)&#xD;&#xA;- Move NFD api to a separate go mod (#1600)&#xD;&#xA;- api/nfd: run go mod tidy (#1661)&#xD;&#xA;- Fix Make generate   (#1662)&#xD;&#xA;- apis/nfd/validate: loosen validation of feature annotations (#1633)&#xD;&#xA;- nfd-master: use separate k8s api clients for each updater (#1653)&#xD;&#xA;- nfd-master: stop node-updater pool before reconfiguring api-controller (#1660)&#xD;&#xA;- build(deps): bump golang.org/x/net from 0.20.0 to 0.23.0 (#1665)&#xD;&#xA;- chore/nfd-master: remove warnings in nfd-master unit tests file (#1668)&#xD;&#xA;- build(deps): bump golang.org/x/net from 0.20.0 to 0.23.0 in api/nfd (#1666)&#xD;&#xA;- apis/nfd: add unit tests for match name functions (#1667)&#xD;&#xA;- apis/nfd: no error on ops that never match (#1670)&#xD;&#xA;- api/nfd: use varargs in the NewInstanceFeatures helper (#1669)&#xD;&#xA;- scripts/test-infra: bump golangci-lint to v1.57.2 (#1674)&#xD;&#xA;- add ARMv7 support (#1659)&#xD;&#xA;- docs: document trade-offs in memory configuration (#1651)&#xD;&#xA;- go.mod: bump kubernetes to v1.30 (#1675)&#xD;&#xA;- cloudbuild.yaml: change machine type to e1-highcpu-32 (#1678)&#xD;&#xA;- test/e2e: stop importing kubernetes test/e2e (#1680)&#xD;&#xA;- hack/init-buildx.sh: fix broken patter matching (#1683)&#xD;&#xA;- Disable armv7 builds  (#1677)&#xD;&#xA;- cloudbuild.yaml: downgrade machine type to e2-highcpu-8 (#1685)&#xD;&#xA;- Update update_codegen.sh for v0.30 version of codegen tools  (#1681)&#xD;&#xA;- Dependabot: Add proper dependabot config file (#1679)&#xD;&#xA;- build(deps): bump azure/setup-helm from 3 to 4 (#1686)&#xD;&#xA;- build(deps): bump actions/checkout from 1 to 4 (#1687)&#xD;&#xA;- build(deps): bump golang.org/x/net from 0.23.0 to 0.24.0 (#1689)&#xD;&#xA;- build(deps): bump sigs.k8s.io/yaml from 1.3.0 to 1.4.0 (#1691)&#xD;&#xA;- build(deps): bump github.com/onsi/gomega from 1.31.0 to 1.33.0 (#1692)&#xD;&#xA;- build(deps): bump github.com/onsi/ginkgo/v2 from 2.15.0 to 2.17.2 (#1690)&#xD;&#xA;- build(deps): bump github.com/jaypipes/ghw from 0.8.1-0.20210827132705-c7224150a17e to 0.12.0 (#1688)&#xD;&#xA;- apis/nfd: increase unit test coverage (#1693)&#xD;&#xA;- build: specify buildx builder name everywhere (#1684)&#xD;&#xA;- source/kernel: silence misleading error on selinux detection (#1694)&#xD;&#xA;- build(deps): bump github.com/klauspost/cpuid/v2 from 2.2.6 to 2.2.7 (#1695)&#xD;&#xA;- build(deps): bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#1696)&#xD;&#xA;- build(deps): bump github.com/google/uuid from 1.5.0 to 1.6.0 (#1698)&#xD;&#xA;- build(deps): bump github.com/onsi/gomega from 1.33.0 to 1.33.1 (#1699)&#xD;&#xA;- build(deps): bump github.com/k8stopologyawareschedwg/noderesourcetopology-api from 0.1.0 to 0.1.2 (#1697)&#xD;&#xA;- build(deps): bump golang.org/x/net from 0.24.0 to 0.25.0 (#1701)&#xD;&#xA;- build(deps): bump google.golang.org/grpc from 1.60.1 to 1.63.2 (#1702)&#xD;&#xA;- build(deps-dev): bump nokogiri from 1.16.2 to 1.16.5 in /docs (#1706)&#xD;&#xA;- build(deps): bump google.golang.org/protobuf from 1.33.0 to 1.34.1 (#1703)&#xD;&#xA;- build(deps): bump github.com/k8stopologyawareschedwg/podfingerprint from 0.1.2 to 0.2.2 (#1705)&#xD;&#xA;- nfd-master: add DisableAutoPrefix feature gate (#1707)&#xD;&#xA;- Re-add -enable-nodefeature-api cmdline flag (#1708)&#xD;&#xA;- build(deps): bump rexml from 3.2.6 to 3.2.8 in /docs (#1709)&#xD;&#xA;- build(deps): bump github.com/onsi/ginkgo/v2 from 2.17.2 to 2.17.3 (#1711)&#xD;&#xA;- Add NodeFeatureGroup API (#1487)&#xD;&#xA;- api/nfd: document all undocumented fields in the types (#1714)&#xD;&#xA;- nfd-worker: improved log when creating NodeFeature object (#1713)&#xD;&#xA;- apis/nfd: allow different types of features of the same name (#1671)&#xD;&#xA;- cpu: advertise AVX10 version (#1673)&#xD;&#xA;- source/cpu: disable AVX10 label (#1715)&#xD;&#xA;- docs/helm: document all feature gates (#1716)&#xD;&#xA;- build(deps): bump github.com/onsi/ginkgo/v2 from 2.17.3 to 2.19.0 (#1717)&#xD;&#xA;- docs: add more cross-references to NodeFeatureGroup API (#1718)</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump to latest upstream version in Makefile</summary>
            <p>1 file(s) updated with &#34;TAG := v0.16.0$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

