### PR TITLE
Bump to upstream version v0.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go-assert-boring.sh bin/*
 
 # Build node feature discovery
 ARG ARCH="amd64"
-ARG TAG=v0.16.0
+ARG TAG=v0.16.1
 ARG PKG="github.com/kubernetes-sigs/node-feature-discovery"
 RUN git clone --depth=1 https://${PKG}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SRC ?= "github.com/kubernetes-sigs/node-feature-discovery"
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v0.16.0$(BUILD_META)
+TAG := v0.16.1$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION
UpdateCli is choosing a release image based on the latest chronological date, when we really want to use the image tagged as the `latest` github release

Replaces: https://github.com/rancher/image-build-node-feature-discovery/pull/35