### PR TITLE
Bump nfd to the upstream `v0.15.6` version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go-assert-boring.sh bin/*
 
 # Build node feature discovery
 ARG ARCH="amd64"
-ARG TAG=v0.16.4
+ARG TAG=v0.15.6
 ARG PKG="github.com/kubernetes-sigs/node-feature-discovery"
 RUN git clone --depth=1 https://${PKG}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GO_IMAGE=rancher/hardened-build-base:v1.22.6b1
 ARG BASE_IMAGE_MINIMAL=registry.suse.com/bci/bci-micro:latest
 
 ######
-FROM ${GO_IMAGE} as builder
+FROM ${GO_IMAGE} AS builder
 # Build and install the grpc-health-probe binary
 ENV GRPC_HEALTH_PROBE_VERSION=v0.4.18
 ARG GHP_PKG="github.com/grpc-ecosystem/grpc-health-probe"
@@ -36,7 +36,7 @@ RUN go-assert-boring.sh bin/*
 
 ######
 # Create minimal variant of the production image
-FROM ${BASE_IMAGE_MINIMAL} as minimal
+FROM ${BASE_IMAGE_MINIMAL} AS minimal
 # Run as unprivileged user
 USER 65534:65534
 # Use more verbose logging of gRPC

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SRC ?= "github.com/kubernetes-sigs/node-feature-discovery"
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v0.16.4$(BUILD_META)
+TAG := v0.15.6$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))

--- a/updatecli/updatecli.d/update-upstream.yaml
+++ b/updatecli/updatecli.d/update-upstream.yaml
@@ -15,6 +15,7 @@ sources:
        prerelease: false
      versionfilter:
        kind: semver
+       pattern: "~0.15"
 
 targets:
   dockerfile:


### PR DESCRIPTION
Also pins future UpdateCli bumps to the `v0.15.x` minor version
Works: https://github.com/mgfritch/image-build-node-feature-discovery/pull/2