### PR TITLE
Fixup SLSAv1 provenance image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,11 @@ jobs:
     - name: Build and push image
       uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        image: rancher/hardened-node-feature-discovery
+        image: hardened-node-feature-discovery
         tag: ${{ github.event.release.tag_name }}
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-
 
         prime-repo: rancher
         prime-registry: ${{ env.PRIME_REGISTRY }}


### PR DESCRIPTION
The `publish-image` action is incorrectly signing/attesting using an image with the repository name listed twice:

```
<registry>/rancher/rancher/hardened-node-feature-discovery@<sha256>
```

See also: https://github.com/rancher/ecm-distro-tools/blob/2cc80e162512f94d562a31895f0b33b44b707d33/actions/publish-image/action.yaml#L186