### PR TITLE
Move to bci-nano

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE=rancher/hardened-build-base:v1.24.13b1
-ARG BASE_IMAGE_MINIMAL=registry.suse.com/bci/bci-micro:latest
+ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
 
 ######
 FROM ${GO_IMAGE} AS builder
@@ -36,7 +36,7 @@ RUN go-assert-boring.sh bin/*
 
 ######
 # Create minimal variant of the production image
-FROM ${BASE_IMAGE_MINIMAL} AS minimal
+FROM ${BCI_IMAGE} AS minimal
 # Run as unprivileged user
 USER 65534:65534
 # Use more verbose logging of gRPC

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-PKG ?= "github.com/kubernetes-sigs/node-feature-discovery"
-SRC ?= "github.com/kubernetes-sigs/node-feature-discovery"
 TAG ?= ${GITHUB_ACTION_TAG}
 
 REPO ?= rancher
@@ -44,8 +42,6 @@ image-build:
 		--pull \
 		--platform=$(ARCH) \
 		--build-arg ARCH=$(ARCH) \
-		--build-arg PKG=$(PKG) \
-		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--tag $(IMAGE) \
 		--tag $(IMAGE)-$(ARCH) \
@@ -60,8 +56,6 @@ push-image:
 		--attest type=provenance,mode=max \
 		--platform=$(TARGET_PLATFORMS) \
 		--build-arg ARCH=$(ARCH) \
-		--build-arg PKG=$(PKG) \
-		--build-arg SRC=$(SRC) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--tag $(IMAGE) \
 		--tag $(IMAGE)-$(ARCH) \
@@ -81,7 +75,5 @@ log:
 	@echo "ARCH=$(ARCH)"
 	@echo "TAG=$(TAG:$(BUILD_META)=)"
 	@echo "ORG=$(ORG)"
-	@echo "PKG=$(PKG)"
-	@echo "SRC=$(SRC)"
 	@echo "BUILD_META=$(BUILD_META)"
 	@echo "UNAME_M=$(UNAME_M)"


### PR DESCRIPTION
## Verification
- BCI Nano contains `/etc/ssl/ca-bundle.pem` for Kubernetes API TLS.
- The image builds successfully with Docker BuildKit and BCI Nano.
- Existing `go-assert-static.sh` and `go-assert-boring.sh` checks pass for NFD and `grpc-health-probe`.
- `nfd-worker --help` runs successfully as UID `65534:65534`.
- `grpc_health_probe -help` runs successfully as UID `65534:65534`.
- The copied worker configuration and binaries are available in the final image.


Signed-off-by: Derek Nola <derek.nola@suse.com>